### PR TITLE
Feat: Add trigger bulk event function

### DIFF
--- a/novu/dto/event.py
+++ b/novu/dto/event.py
@@ -1,5 +1,6 @@
 """This module is used to gather all DTO definitions related to the Event resource in Novu"""
 import dataclasses
+from typing import List, Optional, Union
 
 from novu.dto.base import CamelCaseDto
 from novu.enums import EventStatus
@@ -17,3 +18,26 @@ class EventDto(CamelCaseDto["EventDto"]):
 
     transaction_id: str
     """Transaction id for trigger."""
+
+
+@dataclasses.dataclass
+class InputEventDto(CamelCaseDto["InputEventDto"]):
+    """Definition of an event used as an input"""
+
+    name: str
+    """The name of the template trigger to activate."""
+
+    recipients: Union[str, List[str]]
+    """A subscriber ID (or a list of subscriber ID) to reach with this trigger."""
+
+    payload: dict
+    """A JSON serializable python dict to pass additional custom information."""
+
+    overrides: Optional[dict] = None
+    """A JSON serializable python dict used to override provider specific configurations."""
+
+    transaction_id: Optional[str] = None
+    """A unique ID for this transaction."""
+
+    actor: Optional[str] = None
+    """It is used to display the Avatar of the provided actor's subscriber id."""


### PR DESCRIPTION
We experienced some errors when sending many triggers (>1200) to our Novu instance. To reduce api calls we implemented a function to use the provided bulk trigger endpoint from Novu.

I merged `main` into this feature branch because `alpha` is currently behind `main`. If you rebase `alpha` to `main` I can also rebase this feature branch.

Somehow the usage of the bulk trigger event does not work as fast as a single trigger. It is still faster than triggering single events (tested with 50) but I would expect it to be as quick as just one trigger.
The problem is that the fixed timeout of 5s in function `novu.api.base.handle_request` will be reached quite quickly when using the theoretical limit of 100 events on the bulk trigger endpoint (I barely came over 50 events when testing with a local docker instance). So we may need to make the timeout dynamic on this one.

I did not change the version number or added a new entry to the changelog yet because this was previously done on the alpha release (changes in this PR are the changes from main).

