### PR TITLE
fix: allow Novu's enums to be JSON-serializable

### DIFF
--- a/novu/enums/__init__.py
+++ b/novu/enums/__init__.py
@@ -13,7 +13,6 @@ from novu.enums.notification import (
     NotificationStepMetadataType,
     NotificationStepMetadataUnit,
 )
-from novu.enums.polyfill import StrEnum
 from novu.enums.provider import (
     ChatProviderIdEnum,
     CredentialsKeyEnum,
@@ -48,5 +47,4 @@ __all__ = [
     "StepFilterType",
     "StepFilterValue",
     "TemplateVariableTypeEnum",
-    "StrEnum",
 ]

--- a/novu/enums/__init__.py
+++ b/novu/enums/__init__.py
@@ -13,6 +13,7 @@ from novu.enums.notification import (
     NotificationStepMetadataType,
     NotificationStepMetadataUnit,
 )
+from novu.enums.polyfill import StrEnum
 from novu.enums.provider import (
     ChatProviderIdEnum,
     CredentialsKeyEnum,
@@ -47,4 +48,5 @@ __all__ = [
     "StepFilterType",
     "StepFilterValue",
     "TemplateVariableTypeEnum",
+    "StrEnum",
 ]

--- a/novu/enums/change.py
+++ b/novu/enums/change.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Change resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class ChangeKind(Enum):
+class ChangeKind(StrEnum):
     """This enumeration define all kinds of change in Novu"""
 
     FEED = "Feed"

--- a/novu/enums/channel.py
+++ b/novu/enums/channel.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Channel resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class Channel(Enum):
+class Channel(StrEnum):
     """This enumeration define all available channel in Novu"""
 
     EMAIL = "email"
@@ -22,7 +22,7 @@ class Channel(Enum):
     """Push channel (Expo, Firebase Cloud Messaging, ...)"""
 
 
-class ChannelExtended(Enum):
+class ChannelExtended(StrEnum):
     """
     This enumeration define all available channel in Novu and intermediate provider between channel.
 

--- a/novu/enums/event.py
+++ b/novu/enums/event.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Event resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class EventStatus(Enum):
+class EventStatus(StrEnum):
     """This enumeration define possible status of an event"""
 
     PROCESSED = "processed"

--- a/novu/enums/execution.py
+++ b/novu/enums/execution.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Execution resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class ExecutionSource(Enum):
+class ExecutionSource(StrEnum):
     """This enumeration define all sources possible for an execution in Novu"""
 
     CREDENTIALS = "Credentials"
@@ -18,7 +18,7 @@ class ExecutionSource(Enum):
     """Execution detail source is webhook"""
 
 
-class ExecutionStatus(Enum):
+class ExecutionStatus(StrEnum):
     """This enumeration define all status possible for an execution in Novu"""
 
     SUCCESS = "Success"

--- a/novu/enums/field.py
+++ b/novu/enums/field.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Field resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class FieldFilterPartOperator(Enum):
+class FieldFilterPartOperator(StrEnum):
     """This enumeration define possible operator for a field filter part"""
 
     LARGER = "LARGER"
@@ -48,7 +48,7 @@ class FieldFilterPartOperator(Enum):
     """Not equal operator (``in``)"""
 
 
-class FieldFilterPartOn(Enum):
+class FieldFilterPartOn(StrEnum):
     """This enumeration define possible trigger (``on``) for a field filter part"""
 
     SUBSCRIBER = "subscriber"
@@ -67,7 +67,7 @@ class FieldFilterPartOn(Enum):
     """Allow to check if the subscriber is online in last X given minutes"""
 
 
-class FieldFilterPartTimeOperator(Enum):
+class FieldFilterPartTimeOperator(StrEnum):
     """
     This enumeration define possible operator for a filed filter part which is used if
     ``FieldFilterPartDto.on`` is set to ``FieldFilterPartOn.IS_ONLINE_IN_LAST``"""

--- a/novu/enums/notification.py
+++ b/novu/enums/notification.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Notification resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class NotificationStepMetadataType(Enum):
+class NotificationStepMetadataType(StrEnum):
     """This enumeration define possible type of step's metadata"""
 
     REGULAR = "regular"
@@ -15,7 +15,7 @@ class NotificationStepMetadataType(Enum):
     """Metadata for a scheduled step"""
 
 
-class NotificationStepMetadataUnit(Enum):
+class NotificationStepMetadataUnit(StrEnum):
     """This enumeration define possible unit of step's metadata"""
 
     SECONDS = "seconds"

--- a/novu/enums/polyfill.py
+++ b/novu/enums/polyfill.py
@@ -1,0 +1,11 @@
+"""Polyfill of backports related to enums."""
+try:
+    from enum import StrEnum  # type: ignore[attr-defined]
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        """Redefinition of ``StrEnum`` to backport this class from python 3.10."""
+
+
+__all__ = ["StrEnum"]

--- a/novu/enums/provider.py
+++ b/novu/enums/provider.py
@@ -1,9 +1,10 @@
 """This module is used to gather enumerations related to the Provider resource in Novu"""
-from enum import Enum
 from typing import Union
 
+from novu.enums.polyfill import StrEnum
 
-class CredentialsKeyEnum(Enum):
+
+class CredentialsKeyEnum(StrEnum):
     """This enumeration define possible key in a Novu credentials dict"""
 
     API_KEY = "apiKey"
@@ -67,7 +68,7 @@ class CredentialsKeyEnum(Enum):
     """Webhook URL"""
 
 
-class EmailProviderIdEnum(Enum):
+class EmailProviderIdEnum(StrEnum):
     """This enumeration define possible email provider ID.
 
     For more details about their configuration, see https://docs.novu.co/channels/email/
@@ -119,7 +120,7 @@ class EmailProviderIdEnum(Enum):
     """Novu internal mail provider"""
 
 
-class SmsProviderIdEnum(Enum):
+class SmsProviderIdEnum(StrEnum):
     """This enumeration define possible sms provider ID"""
 
     NEXMO = "nexmo"
@@ -156,7 +157,7 @@ class SmsProviderIdEnum(Enum):
     """Click-a-tell sms provider"""
 
 
-class ChatProviderIdEnum(Enum):
+class ChatProviderIdEnum(StrEnum):
     """This enumeration define possible chat provider ID"""
 
     SLACK = "slack"
@@ -169,7 +170,7 @@ class ChatProviderIdEnum(Enum):
     """MS Teams provider for chat messages"""
 
 
-class PushProviderIdEnum(Enum):
+class PushProviderIdEnum(StrEnum):
     """This enumeration define possible push provider ID"""
 
     FCM = "fcm"
@@ -182,7 +183,7 @@ class PushProviderIdEnum(Enum):
     """EXPO notification push provider"""
 
 
-class InAppProviderIdEnum(Enum):
+class InAppProviderIdEnum(StrEnum):
     """This enumeration define possible in_app provider ID"""
 
     NOVU = "novu"

--- a/novu/enums/step_filter.py
+++ b/novu/enums/step_filter.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Step Filter resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class StepFilterType(Enum):
+class StepFilterType(StrEnum):
     """This enumeration define possible type for a step filter"""
 
     BOOL = "BOOLEAN"
@@ -30,7 +30,7 @@ class StepFilterType(Enum):
     """Group filter"""
 
 
-class StepFilterValue(Enum):
+class StepFilterValue(StrEnum):
     """This enumeration define possible value for a step filter"""
 
     AND = "AND"

--- a/novu/enums/template.py
+++ b/novu/enums/template.py
@@ -1,8 +1,8 @@
 """This module is used to gather enumerations related to the Template resource in Novu"""
-from enum import Enum
+from novu.enums.polyfill import StrEnum
 
 
-class TemplateVariableTypeEnum(Enum):
+class TemplateVariableTypeEnum(StrEnum):
     """This enumeration define possible type for a variable in a template"""
 
     STRING = "String"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ disable = "W0212,W0511,R0913"
 [tool.coverage.run]
 branch = true
 command_line = "-m pytest"
-omit = ["tests/*"]
+omit = ["tests/*", "novu/enums/polyfill.py"]
 relative_files = true
 source = ["novu"]
 

--- a/tests/api/test_integration.py
+++ b/tests/api/test_integration.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 from novu.api import IntegrationApi
 from novu.config import NovuConfig
 from novu.dto.integration import IntegrationChannelUsageDto, IntegrationDto
-from novu.enums import Channel, ChatProviderIdEnum
+from novu.enums import Channel, ChatProviderIdEnum, EmailProviderIdEnum
 from tests.factories import MockResponse
 
 
@@ -17,8 +17,8 @@ class IntegrationApiTests(TestCase):
             "_id": "63dfe50ecac5cff328ca5d24",
             "_environmentId": "63dafed97779f59258e38445",
             "_organizationId": "63dafed97779f59258e3843f",
-            "providerId": "nodemailer",
-            "channel": "email",
+            "providerId": EmailProviderIdEnum.CUSTOM_SMTP,
+            "channel": Channel.EMAIL,
             "credentials": {
                 "user": "test",
                 "password": "test",
@@ -36,8 +36,8 @@ class IntegrationApiTests(TestCase):
         cls.response_list = {"data": [cls.integration_json]}
         cls.response_get = {"data": cls.integration_json}
         cls.expected_dto = IntegrationDto(
-            provider_id="nodemailer",
-            channel="email",
+            provider_id=EmailProviderIdEnum.CUSTOM_SMTP,
+            channel=Channel.EMAIL,
             credentials={
                 "user": "test",
                 "password": "test",
@@ -131,8 +131,8 @@ class IntegrationApiTests(TestCase):
 
         result = self.api.create(
             IntegrationDto(
-                provider_id="nodemailer",
-                channel="email",
+                provider_id=EmailProviderIdEnum.CUSTOM_SMTP,
+                channel=Channel.EMAIL,
                 credentials={
                     "user": "test",
                     "password": "test",
@@ -151,8 +151,8 @@ class IntegrationApiTests(TestCase):
             url="sample.novu.com/v1/integrations",
             headers={"Authorization": "ApiKey api-key"},
             json={
-                "providerId": "nodemailer",
-                "channel": "email",
+                "providerId": EmailProviderIdEnum.CUSTOM_SMTP,
+                "channel": Channel.EMAIL,
                 "credentials": {
                     "user": "test",
                     "password": "test",
@@ -174,8 +174,8 @@ class IntegrationApiTests(TestCase):
 
         result = self.api.create(
             IntegrationDto(
-                provider_id="nodemailer",
-                channel="email",
+                provider_id=EmailProviderIdEnum.CUSTOM_SMTP,
+                channel=Channel.EMAIL,
                 credentials={
                     "user": "test",
                     "password": "test",
@@ -195,8 +195,8 @@ class IntegrationApiTests(TestCase):
             url="sample.novu.com/v1/integrations",
             headers={"Authorization": "ApiKey api-key"},
             json={
-                "providerId": "nodemailer",
-                "channel": "email",
+                "providerId": EmailProviderIdEnum.CUSTOM_SMTP,
+                "channel": Channel.EMAIL,
                 "credentials": {
                     "user": "test",
                     "password": "test",
@@ -221,8 +221,8 @@ class IntegrationApiTests(TestCase):
                     "_id": "63dfe50ecac5cff328ca5d24",
                     "_environmentId": "63dafed97779f59258e38445",
                     "_organizationId": "63dafed97779f59258e3843f",
-                    "providerId": ChatProviderIdEnum.MS_TEAMS.value,
-                    "channel": Channel.CHAT.value,
+                    "providerId": ChatProviderIdEnum.MS_TEAMS,
+                    "channel": Channel.CHAT,
                     "active": True,
                     "deleted": False,
                     "createdAt": "2023-02-05T17:19:10.826Z",
@@ -234,8 +234,8 @@ class IntegrationApiTests(TestCase):
 
         result = self.api.create(
             IntegrationDto(
-                channel=Channel.CHAT.value,
-                provider_id=ChatProviderIdEnum.MS_TEAMS.value,
+                channel=Channel.CHAT,
+                provider_id=ChatProviderIdEnum.MS_TEAMS,
                 credentials={},
                 active=True,
             ),
@@ -244,8 +244,8 @@ class IntegrationApiTests(TestCase):
         self.assertEqual(
             result,
             IntegrationDto(
-                provider_id=ChatProviderIdEnum.MS_TEAMS.value,
-                channel=Channel.CHAT.value,
+                provider_id=ChatProviderIdEnum.MS_TEAMS,
+                channel=Channel.CHAT,
                 credentials=None,
                 active=True,
                 _id="63dfe50ecac5cff328ca5d24",
@@ -264,8 +264,8 @@ class IntegrationApiTests(TestCase):
             url="sample.novu.com/v1/integrations",
             headers={"Authorization": "ApiKey api-key"},
             json={
-                "providerId": ChatProviderIdEnum.MS_TEAMS.value,
-                "channel": Channel.CHAT.value,
+                "providerId": ChatProviderIdEnum.MS_TEAMS,
+                "channel": Channel.CHAT,
                 "credentials": {},
                 "active": True,
                 "check": False,
@@ -296,8 +296,8 @@ class IntegrationApiTests(TestCase):
 
         result = self.api.update(
             IntegrationDto(
-                provider_id="nodemailer",
-                channel="email",
+                provider_id=EmailProviderIdEnum.CUSTOM_SMTP,
+                channel=Channel.EMAIL,
                 credentials={
                     "user": "test",
                     "password": "test",
@@ -317,8 +317,8 @@ class IntegrationApiTests(TestCase):
             url="sample.novu.com/v1/integrations/identifier",
             headers={"Authorization": "ApiKey api-key"},
             json={
-                "providerId": "nodemailer",
-                "channel": "email",
+                "providerId": EmailProviderIdEnum.CUSTOM_SMTP,
+                "channel": Channel.EMAIL,
                 "credentials": {
                     "user": "test",
                     "password": "test",
@@ -340,8 +340,8 @@ class IntegrationApiTests(TestCase):
 
         result = self.api.update(
             IntegrationDto(
-                provider_id="nodemailer",
-                channel="email",
+                provider_id=EmailProviderIdEnum.CUSTOM_SMTP,
+                channel=Channel.EMAIL,
                 credentials={
                     "user": "test",
                     "password": "test",
@@ -362,8 +362,8 @@ class IntegrationApiTests(TestCase):
             url="sample.novu.com/v1/integrations/identifier",
             headers={"Authorization": "ApiKey api-key"},
             json={
-                "providerId": "nodemailer",
-                "channel": "email",
+                "providerId": EmailProviderIdEnum.CUSTOM_SMTP,
+                "channel": Channel.EMAIL,
                 "credentials": {
                     "user": "test",
                     "password": "test",
@@ -399,7 +399,7 @@ class IntegrationApiTests(TestCase):
     def test_limit(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(200, {"data": {"limit": 300, "count": 3}})
 
-        result = self.api.limit("email")
+        result = self.api.limit(Channel.EMAIL)
         self.assertIsInstance(result, IntegrationChannelUsageDto)
         self.assertEqual(result.limit, 300)
         self.assertEqual(result.count, 3)

--- a/tests/api/test_subscriber.py
+++ b/tests/api/test_subscriber.py
@@ -11,6 +11,7 @@ from novu.dto.subscriber import (
     SubscriberPreferencePreferenceDto,
     SubscriberPreferenceTemplateDto,
 )
+from novu.enums import Channel
 from tests.factories import MockResponse
 
 
@@ -295,6 +296,40 @@ class SubscriberApiTests(TestCase):
         )
 
         res = self.api.change_channel_preference("subscriber-id", "63daff36c037e013fd82da05", "in_app", True)
+        self.assertEqual(
+            res,
+            SubscriberPreferenceDto(
+                preference=SubscriberPreferencePreferenceDto(
+                    enabled=True, channels=SubscriberPreferenceChannelDto(email=True, in_app=True)
+                ),
+                template=SubscriberPreferenceTemplateDto(
+                    _id="63daff36c037e013fd82da05", name="Absences", critical=False
+                ),
+            ),
+        )
+
+        mock_request.assert_called_once_with(
+            method="PATCH",
+            url="sample.novu.com/v1/subscribers/subscriber-id/preferences/63daff36c037e013fd82da05",
+            headers={"Authorization": "ApiKey api-key"},
+            json={"channel": {"type": "in_app", "enabled": True}},
+            params=None,
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
+    def test_change_channel_preference_using_enum_in_params(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(
+            200,
+            {
+                "data": {
+                    "template": {"_id": "63daff36c037e013fd82da05", "name": "Absences", "critical": False},
+                    "preference": {"enabled": True, "channels": {"email": True, "in_app": True}},
+                }
+            },
+        )
+
+        res = self.api.change_channel_preference("subscriber-id", "63daff36c037e013fd82da05", Channel.IN_APP, True)
         self.assertEqual(
             res,
             SubscriberPreferenceDto(


### PR DESCRIPTION
Allow Novu's enums to be JSON-serializable.

Fix #26