### PR TITLE
feat(api): allow users to provide a `requests` Session

### DIFF
--- a/docs/guides/cookbook.rst
+++ b/docs/guides/cookbook.rst
@@ -13,3 +13,36 @@ There are two ways to change the timeout of the :module:`requests` module that m
 .. code-block:: python
 
     EventApi(...,...,request_timeout=60).trigger_bulk(...)
+
+How to take control over the session of ``requests``?
+-----------------------------------------------------
+
+Sometime, you may want to setup advanced usage involving the use of a ``requests`` :class:`~requests.Session`.
+
+By default, a session is declared for every request you make to the API, but you can also
+provide your own session and reuse it over and over again.
+
+To illustrate this use case, let's take the example of setting up an automatic retry mechanism on
+requests when the API responds with a 502, 503 or 504 HTTP codes.
+
+To do this, before initializing the Event API, we'll first instantiate a :class:`~requests.Session` from the
+:module:`requests` module, then we'ill inject it into the keywords arguments of our API constructor. We finally
+call the method we want to use and retry.
+
+.. code-block:: python
+
+    from requests import Session
+    from requests.adapters import HTTPAdapter, Retry
+
+    from novu.api import EventApi
+
+    session = Session()
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[ 502, 503, 504 ])
+    session.mount("https://api.novu.co", HTTPAdapter(max_retries=retries))
+
+    event_api = EventApi("https://api.novu.co/api/", "<NOVU_API_TOKEN>", session=session)
+    event_api.trigger(
+        name="<YOUR_TEMPLATE_NAME>",
+        recipients="<YOUR_SUBSCRIBER_ID>",
+        payload={},  # Your Novu payload goes here
+    )

--- a/docs/guides/cookbook.rst
+++ b/docs/guides/cookbook.rst
@@ -25,8 +25,8 @@ provide your own session and reuse it over and over again.
 To illustrate this use case, let's take the example of setting up an automatic retry mechanism on
 requests when the API responds with a 502, 503 or 504 HTTP codes.
 
-To do this, before initializing the Event API, we'll first instantiate a :class:`~requests.Session` from the
-:module:`requests` module, then we'ill inject it into the keywords arguments of our API constructor. We finally
+To do this, before initializing the Event API, we will first instantiate a :class:`~requests.Session` from the
+:module:`requests` module, then we will inject it into the keywords arguments of our API constructor. We finally
 call the method we want to use and retry.
 
 .. code-block:: python

--- a/novu/api/base.py
+++ b/novu/api/base.py
@@ -19,8 +19,15 @@ class Api:  # pylint: disable=R0903
     requests_timeout: int = 5
     """This field allow you to change the :param:`~requests.request.timeout` params which is used during API calls."""
 
+    session: Optional[requests.Session] = None
+    """This field allow you to use a :class:`~requests.Session` during API calls."""
+
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
         config = NovuConfig()
 
@@ -29,7 +36,9 @@ class Api:  # pylint: disable=R0903
 
         self._url = url
         self._headers = {"Authorization": f"ApiKey {api_key}"}
+
         self.requests_timeout = requests_timeout or int(os.getenv("NOVU_PYTHON_REQUESTS_TIMEOUT", "5"))
+        self.session = session
 
     def handle_request(
         self,
@@ -61,7 +70,7 @@ class Api:  # pylint: disable=R0903
         else:
             _headers = self._headers
 
-        res: requests.Response = requests.request(
+        res = (self.session.request if self.session else requests.request)(
             method=method,
             url=url,
             headers=_headers,

--- a/novu/api/change.py
+++ b/novu/api/change.py
@@ -3,6 +3,8 @@ This module is used to define the ``ChangeApi``, a python wrapper to interact wi
 """
 from typing import Dict, Generator, List, Optional, Union
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import CHANGES_ENDPOINT
 from novu.dto.change import ChangeDto, PaginatedChangeDto
@@ -12,9 +14,13 @@ class ChangeApi(Api):
     """This class aims to handle all API methods around changes in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._change_url = f"{self._url}{CHANGES_ENDPOINT}"
 

--- a/novu/api/environment.py
+++ b/novu/api/environment.py
@@ -3,6 +3,8 @@ This module is used to define the ``EnvironmentApi``, a python wrapper to intera
 """
 from typing import Dict, Iterator, Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import ENVIRONMENTS_ENDPOINT
 from novu.dto import EnvironmentApiKeyDto, EnvironmentDto
@@ -12,9 +14,13 @@ class EnvironmentApi(Api):
     """This class aims to handle all API methods around environments in Novu"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._environment_url = f"{self._url}{ENVIRONMENTS_ENDPOINT}"
 

--- a/novu/api/event.py
+++ b/novu/api/event.py
@@ -4,6 +4,8 @@ This module is used to define the ``EventApi``, a python wrapper to interact wit
 from collections.abc import Iterable
 from typing import Dict, Iterable as _Iterable, List, Optional, Union
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import EVENTS_ENDPOINT
 from novu.dto.event import EventDto, InputEventDto
@@ -14,9 +16,13 @@ class EventApi(Api):
     """This class aims to handle all API methods around events in Novu"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._event_url = f"{self._url}{EVENTS_ENDPOINT}"
 

--- a/novu/api/execution_detail.py
+++ b/novu/api/execution_detail.py
@@ -4,6 +4,8 @@ to interact with ``ExecutionDetails`` in Novu.
 """
 from typing import Iterator, Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import EXECUTION_DETAILS_ENDPOINT
 from novu.dto import ExecutionDetailDto
@@ -13,9 +15,13 @@ class ExecutionDetailApi(Api):
     """This class aims to handle all API methods around execution details in Novu"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._execution_detail_url = f"{self._url}{EXECUTION_DETAILS_ENDPOINT}"
 

--- a/novu/api/feed.py
+++ b/novu/api/feed.py
@@ -3,6 +3,8 @@ This module is used to define the ``FeedApi``, a python wrapper to interact with
 """
 from typing import Iterator, Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import FEEDS_ENDPOINT
 from novu.dto.feed import FeedDto
@@ -12,9 +14,13 @@ class FeedApi(Api):
     """This class aims to handle all API methods around feeds in Novu"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._feed_url = f"{self._url}{FEEDS_ENDPOINT}"
 

--- a/novu/api/integration.py
+++ b/novu/api/integration.py
@@ -3,6 +3,8 @@ This module is used to define the ``IntregrationApi``, a python wrapper to inter
 """
 from typing import Iterator, Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import INTEGRATIONS_ENDPOINT
 from novu.dto.integration import IntegrationChannelUsageDto, IntegrationDto
@@ -13,9 +15,13 @@ class IntegrationApi(Api):
     """This class aims to handle all API methods around integrations in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._integration_url = f"{self._url}{INTEGRATIONS_ENDPOINT}"
 

--- a/novu/api/layout.py
+++ b/novu/api/layout.py
@@ -3,6 +3,8 @@ This module is used to define the ``LayoutApi``, a python wrapper to interact wi
 """
 from typing import Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import LAYOUTS_ENDPOINT
 from novu.dto.layout import LayoutDto, PaginatedLayoutDto
@@ -12,9 +14,13 @@ class LayoutApi(Api):
     """This class aims to handle all API methods around layout in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._layout_url = f"{self._url}{LAYOUTS_ENDPOINT}"
 

--- a/novu/api/message.py
+++ b/novu/api/message.py
@@ -3,6 +3,8 @@ This module is used to define the ``MessageApi``, a python wrapper to interact w
 """
 from typing import Dict, Optional, Union
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import MESSAGES_ENDPOINT
 from novu.dto.message import PaginatedMessageDto
@@ -12,9 +14,13 @@ class MessageApi(Api):
     """This class aims to handle all API methods around messages in Novu"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._message_url = f"{self._url}{MESSAGES_ENDPOINT}"
 

--- a/novu/api/notification_group.py
+++ b/novu/api/notification_group.py
@@ -4,6 +4,8 @@ to interact with ``NotificationGroup`` in Novu.
 """
 from typing import Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import NOTIFICATION_GROUPS_ENDPOINT
 from novu.dto.notification_group import (
@@ -16,9 +18,13 @@ class NotificationGroupApi(Api):
     """This class aims to handle all API methods around notification groups in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._notification_group_url = f"{self._url}{NOTIFICATION_GROUPS_ENDPOINT}"
 

--- a/novu/api/notification_template.py
+++ b/novu/api/notification_template.py
@@ -4,6 +4,8 @@ to interact with ``NotificationTemplate`` in Novu.
 """
 from typing import Optional
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import NOTIFICATION_TEMPLATES_ENDPOINT
 from novu.dto.notification_template import (
@@ -17,9 +19,13 @@ class NotificationTemplateApi(Api):
     """This class aims to handle all API methods around notification templates in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._notification_template_url = f"{self._url}{NOTIFICATION_TEMPLATES_ENDPOINT}"
 

--- a/novu/api/subscriber.py
+++ b/novu/api/subscriber.py
@@ -3,6 +3,8 @@ This module is used to define the ``SubscriberApi``, a python wrapper to interac
 """
 from typing import Dict, Iterator, List, Optional, Union
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import SUBSCRIBERS_ENDPOINT
 from novu.dto.subscriber import (
@@ -17,9 +19,13 @@ class SubscriberApi(Api):
     """This class aims to handle all API methods around subscribers in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._subscriber_url = f"{self._url}{SUBSCRIBERS_ENDPOINT}"
 

--- a/novu/api/topic.py
+++ b/novu/api/topic.py
@@ -3,6 +3,8 @@ This module is used to define the ``TopicApi``, a python wrapper to interact wit
 """
 from typing import Dict, List, Optional, Tuple, Union
 
+import requests
+
 from novu.api.base import Api
 from novu.constants import TOPICS_ENDPOINT
 from novu.dto.topic import PaginatedTopicDto, TopicDto
@@ -12,9 +14,13 @@ class TopicApi(Api):
     """This class aims to handle all API methods around topics in API"""
 
     def __init__(
-        self, url: Optional[str] = None, api_key: Optional[str] = None, requests_timeout: Optional[int] = None
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        requests_timeout: Optional[int] = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
-        super().__init__(url, api_key, requests_timeout)
+        super().__init__(url=url, api_key=api_key, requests_timeout=requests_timeout, session=session)
 
         self._topic_url = f"{self._url}{TOPICS_ENDPOINT}"
 

--- a/tests/api/test_base.py
+++ b/tests/api/test_base.py
@@ -79,3 +79,22 @@ class ApiTests(TestCase):
             params=None,
             timeout=60,
         )
+
+    @mock.patch("requests.request")
+    def test_use_requests_session(self, mock_request: mock.MagicMock) -> None:
+        session_mock = mock.MagicMock()
+        session_mock.request.return_value = MockResponse(200, {})
+        api = Api(session=session_mock)
+
+        res = api.handle_request("GET", api._url, headers={"MyHeader": "value"})
+        self.assertEqual(res, {})
+
+        mock_request.assert_not_called()
+        session_mock.request.assert_called_once_with(
+            method="GET",
+            url="sample.novu.com",
+            headers={"Authorization": "ApiKey api-key", "MyHeader": "value"},
+            json=None,
+            params=None,
+            timeout=5,
+        )


### PR DESCRIPTION
Allow users to provide a `requests` Session to handle advanced case like setting up an automatic retry mechanism.

Related to #25