### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To do this, you will need to:
 ```python
 from novu.api import EventApi
 
-event_api = EventApi("https://api.novu.co/api/", "<NOVU_API_TOKEN>")
+event_api = EventApi("https://api.novu.co", "<NOVU_API_TOKEN>")
 event_api.trigger(
     name="<YOUR_TEMPLATE_NAME>",
     recipients="<YOUR_SUBSCRIBER_ID>",


### PR DESCRIPTION
Removing /api/ from api url.
The `EVENTS_ENDPOINT` includes `/` so it's redundent.  In addition, the `/api` route doesn't work properly, returns not found (404).