### PR TITLE
fix(change): promoted path parms is required for listing

### DIFF
--- a/novu/api/change.py
+++ b/novu/api/change.py
@@ -24,17 +24,20 @@ class ChangeApi(Api):
 
         self._change_url = f"{self._url}{CHANGES_ENDPOINT}"
 
-    def list(self, page: Optional[int] = None, limit: Optional[int] = None) -> PaginatedChangeDto:
+    def list(
+        self, page: Optional[int] = None, limit: Optional[int] = None, promoted: str = "false"
+    ) -> PaginatedChangeDto:
         """List existing changes
 
         Args:
             page: Page to retrieve. Defaults to None.
             limit: Size of the page to retrieve. Defaults to None.
+            promoted: Required string to retrieve changes.
 
         Returns:
             Paginated list of change
         """
-        payload: Dict[str, Union[int, str]] = {}
+        payload: Dict[str, Union[int, str]] = {"promoted": promoted}
         if page:
             payload["page"] = page
         if limit:

--- a/tests/api/test_change.py
+++ b/tests/api/test_change.py
@@ -594,7 +594,7 @@ class ChangeApiTests(TestCase):
             url="sample.novu.com/v1/changes",
             headers={"Authorization": "ApiKey api-key"},
             json=None,
-            params={},
+            params={"promoted": "false"},
             timeout=5,
         )
 
@@ -611,7 +611,7 @@ class ChangeApiTests(TestCase):
             url="sample.novu.com/v1/changes",
             headers={"Authorization": "ApiKey api-key"},
             json=None,
-            params={"page": 1, "limit": 10},
+            params={"page": 1, "limit": 10, "promoted": "false"},
             timeout=5,
         )
 


### PR DESCRIPTION
promoted path parms is required for listing

See https://docs.novu.co/api-reference/changes/get-changes