### PR TITLE
fix(notification): list notifications should return a paginated response

### DIFF
--- a/novu/api/base.py
+++ b/novu/api/base.py
@@ -3,14 +3,80 @@ import copy
 import logging
 import os
 from json.decoder import JSONDecodeError
-from typing import Optional
+from typing import Generic, List, Optional, Type, TypeVar
 
 import requests
 
 from novu.config import NovuConfig
+from novu.dto.base import CamelCaseDto
 from novu.helpers import SentryProxy
 
 LOGGER = logging.getLogger(__name__)
+
+
+_C_co = TypeVar("_C_co", bound=CamelCaseDto, covariant=True)
+
+
+class PaginationIterator(Generic[_C_co]):  # pylint: disable=R0902
+    """The class is a generic iterator which allow to iterate directly on result without
+    looking for pagination during handling.
+
+    Args:
+        api: The api used to call
+        item_class: The Dto to parse each items return by API.
+        url: The URL to query during fetch.
+        payload: Payload to query during fetch.
+    """
+
+    def __init__(self, api: "Api", item_class: Type[_C_co], url: str, payload: Optional[dict] = None):
+        self.__item_class = item_class
+        self.__api = api
+        self.__url = url
+        self.__payload = payload or {}
+
+        self.__has_more = False
+        self.__page = 0
+        self.__limit = 10
+        self.__index = 0
+        self.__buffer: List[_C_co] = []
+
+        self.__payload["limit"] = self.__limit
+        self.__payload["page"] = self.__page
+        self.__fetch_data()
+
+    def __iter__(self) -> "PaginationIterator[_C_co]":
+        return self
+
+    def __next__(self) -> _C_co:
+        return self.next()
+
+    def next(self) -> _C_co:
+        """Implementation of the next behavior for the iterator."""
+        if self.__index < len(self.__buffer):
+            result, self.__index = self.__buffer[self.__index], self.__index + 1
+            return result
+
+        if self.__has_more:
+            self.__fetch_data()
+
+            result, self.__index = self.__buffer[self.__index], self.__index + 1
+            return result
+
+        raise StopIteration()
+
+    def __fetch_data(self):
+        self.__payload["page"] = self.__page
+        self.__page += 1
+
+        data = self.__api.handle_request(
+            method="GET",
+            url=self.__url,
+            payload=self.__payload,
+        )
+
+        self.__has_more = data.get("hasMore", data.get("totalCount", 0) > (self.__page + 1 * self.__limit))
+        self.__buffer = list(map(self.__item_class.from_camel_case, data.get("data", [])))
+        self.__index = 0
 
 
 class Api:  # pylint: disable=R0903

--- a/novu/api/message.py
+++ b/novu/api/message.py
@@ -5,9 +5,9 @@ from typing import Dict, Optional, Union
 
 import requests
 
-from novu.api.base import Api
+from novu.api.base import Api, PaginationIterator
 from novu.constants import MESSAGES_ENDPOINT
-from novu.dto.message import PaginatedMessageDto
+from novu.dto.message import MessageDto, PaginatedMessageDto
 
 
 class MessageApi(Api):
@@ -46,6 +46,27 @@ class MessageApi(Api):
             payload["subscriberId"] = subscriber_id
 
         return PaginatedMessageDto.from_camel_case(self.handle_request("GET", self._message_url, payload=payload))
+
+    def stream(
+        self, channel: Optional[str] = None, subscriber_id: Optional[str] = None
+    ) -> PaginationIterator[MessageDto]:
+        """Stream all existing messages into an iterator.
+
+        Args:
+            channel: The channel for the messages you wish to list. Defaults to None.
+            subscriber_id: The subscriberId for the subscriber you like to list messages for
+
+        Returns:
+            An iterator on all messages available.
+        """
+        payload = {}
+
+        if channel:
+            payload["channel"] = channel
+        if subscriber_id:
+            payload["subscriberId"] = subscriber_id
+
+        return PaginationIterator(self, MessageDto, self._message_url, payload=payload)
 
     def delete(self, message_id: str) -> bool:
         """Deletes a message entity from the Novu platform

--- a/novu/api/notification.py
+++ b/novu/api/notification.py
@@ -7,7 +7,11 @@ import requests
 
 from novu.api.base import Api
 from novu.constants import NOTIFICATION_ENDPOINT
-from novu.dto.notification import ActivityGraphStatesDto, ActivityNotificationDto
+from novu.dto.notification import (
+    ActivityGraphStatesDto,
+    ActivityNotificationDto,
+    PaginatedActivityNotificationDto,
+)
 
 
 class NotificationApi(Api):
@@ -26,13 +30,13 @@ class NotificationApi(Api):
 
     def list(
         self,
-        channels: List[str],
-        templates: List[str],
-        emails: List[str],
-        search: str,
+        channels: Optional[List[str]] = None,
+        templates: Optional[List[str]] = None,
+        emails: Optional[List[str]] = None,
+        search: Optional[str] = None,
         page: Optional[int] = 0,
         transaction_id: Optional[str] = None,
-    ) -> ActivityNotificationDto:
+    ) -> PaginatedActivityNotificationDto:
         """Trigger an event to get all notifications.
 
         Args:
@@ -66,8 +70,8 @@ class NotificationApi(Api):
             "page": page,
             "transactionId": transaction_id,
         }
-        return ActivityNotificationDto.from_camel_case(
-            self.handle_request("GET", f"{self._notification_url}", payload=payload)["data"]
+        return PaginatedActivityNotificationDto.from_camel_case(
+            self.handle_request("GET", f"{self._notification_url}", payload=payload)
         )
 
     def stats(self) -> Tuple[int, int]:

--- a/novu/api/notification.py
+++ b/novu/api/notification.py
@@ -5,7 +5,7 @@ from typing import Iterator, List, Optional, Tuple
 
 import requests
 
-from novu.api.base import Api
+from novu.api.base import Api, PaginationIterator
 from novu.constants import NOTIFICATION_ENDPOINT
 from novu.dto.notification import (
     ActivityGraphStatesDto,
@@ -73,6 +73,44 @@ class NotificationApi(Api):
         return PaginatedActivityNotificationDto.from_camel_case(
             self.handle_request("GET", f"{self._notification_url}", payload=payload)
         )
+
+    def stream(
+        self,
+        channels: Optional[List[str]] = None,
+        templates: Optional[List[str]] = None,
+        emails: Optional[List[str]] = None,
+        search: Optional[str] = None,
+        transaction_id: Optional[str] = None,
+    ) -> PaginationIterator[ActivityNotificationDto]:
+        """Stream all existing notifications into an iterator.
+
+        Args:
+            channels: A required parameter, should be an array of strings representing
+                           available notification channels, such as "in_app", "email", "sms",
+                           "chat", and "push".
+
+            templates: A required parameter, should be an array of strings representing
+                             the notification templates.
+
+            emails: A required parameter, should be an array of strings representing
+                        the email addresses associated with the notification.
+
+            search: A required parameter, should be a string representing the search query.
+
+            transaction_id: A required parameter, should be a string representing the
+                                transaction ID associated with the notification.
+
+        Returns:
+            An iterator on all notifications available.
+        """
+        payload = {
+            "channels": channels,
+            "templates": templates,
+            "emails": emails,
+            "search": search,
+            "transactionId": transaction_id,
+        }
+        return PaginationIterator(self, ActivityNotificationDto, self._notification_url, payload=payload)
 
     def stats(self) -> Tuple[int, int]:
         """Gets notifications stats

--- a/novu/api/notification_template.py
+++ b/novu/api/notification_template.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import requests
 
-from novu.api.base import Api
+from novu.api.base import Api, PaginationIterator
 from novu.constants import NOTIFICATION_TEMPLATES_ENDPOINT
 from novu.dto.notification_template import (
     NotificationTemplateDto,
@@ -44,6 +44,14 @@ class NotificationTemplateApi(Api):
         return PaginatedNotificationTemplateDto.from_camel_case(
             self.handle_request("GET", self._notification_template_url, payload=payload)
         )
+
+    def stream(self) -> PaginationIterator[NotificationTemplateDto]:
+        """Stream all existing workflows into an iterator.
+
+        Returns:
+            An iterator on all workflows available.
+        """
+        return PaginationIterator(self, NotificationTemplateDto, self._notification_template_url)
 
     def create(self, notification_template: NotificationTemplateFormDto) -> NotificationTemplateDto:
         """Create a template using the notification template form definition

--- a/novu/api/subscriber.py
+++ b/novu/api/subscriber.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterator, List, Optional, Union
 
 import requests
 
-from novu.api.base import Api
+from novu.api.base import Api, PaginationIterator
 from novu.constants import SUBSCRIBERS_ENDPOINT
 from novu.dto.subscriber import (
     PaginatedSubscriberDto,
@@ -43,6 +43,14 @@ class SubscriberApi(Api):
             payload["page"] = page
 
         return PaginatedSubscriberDto.from_camel_case(self.handle_request("GET", self._subscriber_url, payload=payload))
+
+    def stream(self) -> PaginationIterator[SubscriberDto]:
+        """Stream all existing subscribers into an iterator.
+
+        Returns:
+            An iterator on all subscribers available.
+        """
+        return PaginationIterator(self, SubscriberDto, self._subscriber_url)
 
     def create(self, subscriber: SubscriberDto) -> SubscriberDto:
         """Method to push a given subscriber instance to Novu

--- a/novu/api/tenant.py
+++ b/novu/api/tenant.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Union
 
 import requests
 
-from novu.api.base import Api
+from novu.api.base import Api, PaginationIterator
 from novu.constants import TENANTS_ENDPOINT
 from novu.dto.tenant import PaginatedTenantDto, TenantDto
 
@@ -41,6 +41,14 @@ class TenantApi(Api):
             payload["limit"] = limit
 
         return PaginatedTenantDto.from_camel_case(self.handle_request("GET", self._tenant_url, payload=payload))
+
+    def stream(self) -> PaginationIterator[TenantDto]:
+        """Stream all existing tenants into an iterator.
+
+        Returns:
+            An iterator on all tenants available.
+        """
+        return PaginationIterator(self, TenantDto, self._tenant_url)
 
     def create(self, identifier: str, name: str, data: Optional[dict] = None) -> TenantDto:
         """Create a tenant

--- a/novu/dto/__init__.py
+++ b/novu/dto/__init__.py
@@ -26,6 +26,7 @@ from novu.dto.notification import (
     ActivityNotificationSubscriberResponseDTO,
     ActivityNotificationTemplateResponseDto,
     ActivityNotificationTriggerResponseDto,
+    PaginatedActivityNotificationDto,
 )
 from novu.dto.notification_group import (
     NotificationGroupDto,
@@ -82,6 +83,7 @@ __all__ = [
     "ActivityNotificationExecutionDetailResponseDto",
     "ActivityNotificationJobResponseDto",
     "ActivityNotificationDto",
+    "PaginatedActivityNotificationDto",
     "PaginatedChangeDto",
     "PaginatedLayoutDto",
     "PaginatedMessageDto",

--- a/novu/dto/notification.py
+++ b/novu/dto/notification.py
@@ -195,3 +195,22 @@ class ActivityGraphStatesDto(CamelCaseDto["ActivityGraphStatesDto"]):
 
     channels: List[Channel]
     """Graph states' channel."""
+
+
+@dataclasses.dataclass
+class PaginatedActivityNotificationDto(CamelCaseDto["PaginatedActivityNotificationDto"]):
+    """Definition of paginated subscribers"""
+
+    page: int = 0
+    """Page number"""
+
+    has_more: bool = False
+    """If their is more notifications available"""
+
+    page_size: int = 0
+    """Page size"""
+
+    data: DtoIterableDescriptor[ActivityNotificationDto] = DtoIterableDescriptor[ActivityNotificationDto](
+        default_factory=list, item_cls=ActivityNotificationDto
+    )
+    """Data"""

--- a/tests/api/test_message.py
+++ b/tests/api/test_message.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 
 from novu.api import MessageApi
+from novu.api.base import PaginationIterator
 from novu.config import NovuConfig
 from novu.dto.message import MessageDto, PaginatedMessageDto
 from novu.enums import Channel
@@ -92,6 +93,40 @@ class MessageApiTests(TestCase):
         res = self.api.list(10, 0, Channel.IN_APP.value, "63dafedbc037e013fd82d37a")
         self.assertIsInstance(res, PaginatedMessageDto)
         self.assertEqual(list(res.data), [self.expected_dto])
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="sample.novu.com/v1/messages",
+            headers={"Authorization": "ApiKey api-key"},
+            json=None,
+            params={"limit": 10, "page": 0, "channel": "in_app", "subscriberId": "63dafedbc037e013fd82d37a"},
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
+    def test_stream_messages(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(200, {"data": [self.response_json]})
+
+        res = self.api.stream()
+        self.assertIsInstance(res, PaginationIterator)
+        self.assertEqual(list(res), [self.expected_dto])
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="sample.novu.com/v1/messages",
+            headers={"Authorization": "ApiKey api-key"},
+            json=None,
+            params={"limit": 10, "page": 0},
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
+    def test_stream_messages_with_filters(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(200, {"data": [self.response_json]})
+
+        res = self.api.stream(Channel.IN_APP.value, "63dafedbc037e013fd82d37a")
+        self.assertIsInstance(res, PaginationIterator)
+        self.assertEqual(list(res), [self.expected_dto])
 
         mock_request.assert_called_once_with(
             method="GET",

--- a/tests/api/test_notification.py
+++ b/tests/api/test_notification.py
@@ -11,6 +11,7 @@ from novu.dto.notification import (
     ActivityNotificationSubscriberResponseDTO,
     ActivityNotificationTemplateResponseDto,
     ActivityNotificationTriggerResponseDto,
+    PaginatedActivityNotificationDto,
 )
 from tests.factories import MockResponse
 
@@ -77,6 +78,7 @@ class NotificationApiTests(TestCase):
             ],
         }
         cls.response_notification = {"data": cls.notification_json}
+        cls.response_list = {"page": 0, "hasMore": False, "pageSize": 10, "data": [cls.notification_json]}
         cls.expected_dto = ActivityNotificationDto(
             _id="63dafed97779f59258e44954",
             _environment_id="63dafed97779f59258e38445",
@@ -138,15 +140,16 @@ class NotificationApiTests(TestCase):
 
     @mock.patch("requests.request")
     def test_list(self, mock_request: mock.MagicMock) -> None:
-        mock_request.return_value = MockResponse(200, self.response_notification)
+        mock_request.return_value = MockResponse(200, self.response_list)
 
         channels = ["in_app"]
         templates = ["Template3"]
         emails = ["max.moe@example.com"]
         search = "example"
-        notification_result = self.api.list(channels, templates, emails, search)
+        result = self.api.list(channels, templates, emails, search)
 
-        self.assertIsInstance(notification_result, ActivityNotificationDto)
+        self.assertIsInstance(result, PaginatedActivityNotificationDto)
+        notification_result = result.data[0]
         self.assertEqual(notification_result._id, self.expected_dto._id)
         self.assertEqual(notification_result._environment_id, self.expected_dto._environment_id)
         self.assertEqual(notification_result._organization_id, self.expected_dto._organization_id)

--- a/tests/api/test_notification_template.py
+++ b/tests/api/test_notification_template.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 
 from novu.api import NotificationTemplateApi
+from novu.api.base import PaginationIterator
 from novu.config import NovuConfig
 from novu.dto import (
     NotificationGroupDto,
@@ -173,6 +174,23 @@ class NotificationTemplateApiTests(TestCase):
             headers={"Authorization": "ApiKey api-key"},
             json=None,
             params={"page": 1, "limit": 10},
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
+    def test_stream_notification_template(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(200, self.response_list)
+
+        result = self.api.stream()
+        self.assertIsInstance(result, PaginationIterator)
+        self.assertEqual(list(result), [self.expected_dto])
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="sample.novu.com/v1/notification-templates",
+            headers={"Authorization": "ApiKey api-key"},
+            json=None,
+            params={"page": 0, "limit": 10},
             timeout=5,
         )
 

--- a/tests/api/test_subscriber.py
+++ b/tests/api/test_subscriber.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from unittest import TestCase, mock
 
 from novu.api import SubscriberApi
+from novu.api.base import PaginationIterator
 from novu.config import NovuConfig
 from novu.dto.subscriber import (
     PaginatedSubscriberDto,
@@ -88,6 +89,23 @@ class SubscriberApiTests(TestCase):
             headers={"Authorization": "ApiKey api-key"},
             json=None,
             params={"page": 1},
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
+    def test_stream_subscriber(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(200, self.response_list)
+
+        result = self.api.stream()
+        self.assertIsInstance(result, PaginationIterator)
+        self.assertEqual(list(result), [self.expected_dto])
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="sample.novu.com/v1/subscribers",
+            headers={"Authorization": "ApiKey api-key"},
+            json=None,
+            params={"page": 0, "limit": 10},
             timeout=5,
         )
 


### PR DESCRIPTION
As specified in https://docs.novu.co/api-reference/notification/get-notifications, notifications are paginated for the list