### PR TITLE
feat(event): #94 - support tenant in event api

### DIFF
--- a/novu/api/event.py
+++ b/novu/api/event.py
@@ -34,6 +34,7 @@ class EventApi(Api):
         overrides: Optional[dict] = None,
         transaction_id: Optional[str] = None,
         actor: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> EventDto:
         """Trigger event is the main way to send notification to subscribers.
 
@@ -64,6 +65,10 @@ class EventApi(Api):
             actor:
                 It is used to display the Avatar of the provided actor's subscriber id. Defaults to None.
 
+            tenant:
+                It is used to specify a tenant context during trigger event.
+                If a new tenant object is provided, we will create a new tenant.
+
         Returns:
             Create Event definition in Novu
         """
@@ -74,6 +79,8 @@ class EventApi(Api):
             payload["actor"] = actor
         if transaction_id:
             payload["transactionId"] = transaction_id
+        if tenant:
+            payload["tenant"] = tenant
 
         return EventDto.from_camel_case(self.handle_request("POST", self._event_url, payload)["data"])
 
@@ -99,6 +106,8 @@ class EventApi(Api):
                 event_payload["actor"] = event.actor
             if event.transaction_id:
                 event_payload["transactionId"] = event.transaction_id
+            if event.tenant:
+                event_payload["tenant"] = event.tenant
 
             payload["events"].append(event_payload)
 
@@ -119,6 +128,7 @@ class EventApi(Api):
         overrides: Optional[dict] = None,
         transaction_id: Optional[str] = None,
         actor: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> EventDto:
         """Trigger event is the main way to send notification to topic's subscribers.
 
@@ -142,6 +152,10 @@ class EventApi(Api):
             actor:
                 It is used to display the Avatar of the provided actor's subscriber id. Defaults to None.
 
+            tenant:
+                It is used to specify a tenant context during trigger event.
+                If a new tenant object is provided, we will create a new tenant.
+
         Returns:
             Create Event definition in Novu
         """
@@ -154,6 +168,8 @@ class EventApi(Api):
             payload["actor"] = actor
         if transaction_id:
             payload["transactionId"] = transaction_id
+        if tenant:
+            payload["tenant"] = tenant
 
         return EventDto.from_camel_case(self.handle_request("POST", self._event_url, payload)["data"])
 
@@ -164,6 +180,7 @@ class EventApi(Api):
         overrides: Optional[dict] = None,
         transaction_id: Optional[str] = None,
         actor: Optional[str] = None,
+        tenant: Optional[str] = None,
     ):
         """Trigger a broadcast event to all existing subscribers, could be used to send announcements, etc.
 
@@ -182,6 +199,10 @@ class EventApi(Api):
             actor:
                 It is used to display the Avatar of the provided actor's subscriber id. Defaults to None.
 
+            tenant:
+                It is used to specify a tenant context during trigger event.
+                If a new tenant object is provided, we will create a new tenant.
+
         Returns:
             Create Event definition in Novu
         """
@@ -192,6 +213,8 @@ class EventApi(Api):
             payload["actor"] = actor
         if transaction_id:
             payload["transactionId"] = transaction_id
+        if tenant:
+            payload["tenant"] = tenant
 
         return EventDto.from_camel_case(self.handle_request("POST", f"{self._event_url}/broadcast", payload)["data"])
 

--- a/novu/dto/event.py
+++ b/novu/dto/event.py
@@ -41,3 +41,8 @@ class InputEventDto(CamelCaseDto["InputEventDto"]):
 
     actor: Optional[str] = None
     """It is used to display the Avatar of the provided actor's subscriber id."""
+
+    tenant: Optional[str] = None
+    """It is used to specify a tenant context during trigger event.
+    If a new tenant object is provided, we will create a new tenant.
+    """

--- a/tests/api/test_event.py
+++ b/tests/api/test_event.py
@@ -9,6 +9,8 @@ from tests.factories import MockResponse
 
 
 class EventApiTests(TestCase):
+    api: EventApi
+
     @classmethod
     def setUpClass(cls) -> None:
         NovuConfig.configure("sample.novu.com", "api-key")
@@ -17,14 +19,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_with_single_recipient(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.trigger("test-template", "sample-recipient", {})
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -38,14 +40,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_with_multiple_recipients(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.trigger("test-template", ["sample-recipient-1", "sample-recipient-2"], {})
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -59,14 +61,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_with_overrides(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.trigger("test-template", "sample-recipient", {}, {"an": "override"})
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -80,14 +82,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_with_actor(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.trigger("test-template", "sample-recipient", {}, actor="actor-id")
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -101,14 +103,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_with_transaction_id(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.trigger("test-template", "sample-recipient", {}, transaction_id="sample-test")
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -120,9 +122,30 @@ class EventApiTests(TestCase):
         )
 
     @mock.patch("requests.request")
+    def test_trigger_with_tenant(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
+        )
+
+        result = self.api.trigger("test-template", "sample-recipient", {}, tenant="tenant-id")
+
+        self.assertIsInstance(result, EventDto)
+        self.assertTrue(result.acknowledged)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
+        self.assertEqual(result.transaction_id, "sample-test")
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="sample.novu.com/v1/events/trigger",
+            headers={"Authorization": "ApiKey api-key"},
+            json={"name": "test-template", "to": "sample-recipient", "payload": {}, "tenant": "tenant-id"},
+            params=None,
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
     def test_trigger_topic_with_single_topic(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         topic = TriggerTopicDto("topic-key", "type")
@@ -130,7 +153,7 @@ class EventApiTests(TestCase):
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -144,7 +167,7 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_topic_with_multiple_topics(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         topic_1 = TriggerTopicDto("topic-key-1", "type")
@@ -153,7 +176,7 @@ class EventApiTests(TestCase):
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -171,7 +194,7 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_topic_with_overrides(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         topic = TriggerTopicDto("topic-key", "type")
@@ -179,7 +202,7 @@ class EventApiTests(TestCase):
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -198,7 +221,7 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_topic_with_actor(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         topic = TriggerTopicDto("topic-key", "type")
@@ -206,7 +229,7 @@ class EventApiTests(TestCase):
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -225,7 +248,7 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_trigger_topic_with_transaction_id(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         topic = TriggerTopicDto("topic-key", "type")
@@ -233,7 +256,7 @@ class EventApiTests(TestCase):
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -250,12 +273,39 @@ class EventApiTests(TestCase):
         )
 
     @mock.patch("requests.request")
+    def test_trigger_topic_with_tenant(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
+        )
+
+        topic = TriggerTopicDto("topic-key", "type")
+        result = self.api.trigger_topic("test-template", topic, {}, tenant="tenant-id")
+
+        self.assertIsInstance(result, EventDto)
+        self.assertTrue(result.acknowledged)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
+        self.assertEqual(result.transaction_id, "sample-test")
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="sample.novu.com/v1/events/trigger",
+            headers={"Authorization": "ApiKey api-key"},
+            json={
+                "name": "test-template",
+                "to": [{"topicKey": "topic-key", "type": "type"}],
+                "payload": {},
+                "tenant": "tenant-id",
+            },
+            params=None,
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
     def test_trigger_bulk_with_one_event(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
             201,
             {
                 "data": [
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"},
                 ]
             },
         )
@@ -271,7 +321,7 @@ class EventApiTests(TestCase):
         triggered_event = result[0]
         self.assertIsInstance(triggered_event, EventDto)
         self.assertTrue(triggered_event.acknowledged)
-        self.assertEqual(triggered_event.status, EventStatus.PROCESSED.value)
+        self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
         self.assertEqual(triggered_event.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -294,8 +344,8 @@ class EventApiTests(TestCase):
             201,
             {
                 "data": [
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[0]},
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[1]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[0]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[1]},
                 ]
             },
         )
@@ -312,7 +362,7 @@ class EventApiTests(TestCase):
         for triggered_event in result:
             self.assertIsInstance(triggered_event, EventDto)
             self.assertTrue(triggered_event.acknowledged)
-            self.assertEqual(triggered_event.status, EventStatus.PROCESSED.value)
+            self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
             self.assertIn(triggered_event.transaction_id, transaction_ids)
 
         mock_request.assert_called_once_with(
@@ -337,8 +387,8 @@ class EventApiTests(TestCase):
             201,
             {
                 "data": [
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[0]},
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[1]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[0]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[1]},
                 ]
             },
         )
@@ -355,7 +405,7 @@ class EventApiTests(TestCase):
         for triggered_event in result:
             self.assertIsInstance(triggered_event, EventDto)
             self.assertTrue(triggered_event.acknowledged)
-            self.assertEqual(triggered_event.status, EventStatus.PROCESSED.value)
+            self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
             self.assertIn(triggered_event.transaction_id, transaction_ids)
 
         mock_request.assert_called_once_with(
@@ -380,8 +430,8 @@ class EventApiTests(TestCase):
             201,
             {
                 "data": [
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[0]},
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[1]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[0]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[1]},
                 ]
             },
         )
@@ -398,7 +448,7 @@ class EventApiTests(TestCase):
         for triggered_event in result:
             self.assertIsInstance(triggered_event, EventDto)
             self.assertTrue(triggered_event.acknowledged)
-            self.assertEqual(triggered_event.status, EventStatus.PROCESSED.value)
+            self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
             self.assertIn(triggered_event.transaction_id, transaction_ids)
 
         mock_request.assert_called_once_with(
@@ -423,8 +473,8 @@ class EventApiTests(TestCase):
             201,
             {
                 "data": [
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[0]},
-                    {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": transaction_ids[1]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[0]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[1]},
                 ]
             },
         )
@@ -443,7 +493,7 @@ class EventApiTests(TestCase):
         for triggered_event in result:
             self.assertIsInstance(triggered_event, EventDto)
             self.assertTrue(triggered_event.acknowledged)
-            self.assertEqual(triggered_event.status, EventStatus.PROCESSED.value)
+            self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
             self.assertIn(triggered_event.transaction_id, transaction_ids)
 
         mock_request.assert_called_once_with(
@@ -461,16 +511,59 @@ class EventApiTests(TestCase):
         )
 
     @mock.patch("requests.request")
+    def test_trigger_bulk_with_multiple_events_and_tenant(self, mock_request: mock.MagicMock) -> None:
+        transaction_ids = ["sample-test", "another-sample-test"]
+
+        mock_request.return_value = MockResponse(
+            201,
+            {
+                "data": [
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[0]},
+                    {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": transaction_ids[1]},
+                ]
+            },
+        )
+
+        events = [
+            InputEventDto(name="test-template", recipients="recipient_1", payload={}, tenant="tenant-id"),
+            InputEventDto(name="test-template", recipients="recipient_2", payload={}),
+        ]
+
+        result = self.api.trigger_bulk(events)
+
+        self.assertEqual(len(result), len(events))
+
+        for triggered_event in result:
+            self.assertIsInstance(triggered_event, EventDto)
+            self.assertTrue(triggered_event.acknowledged)
+            self.assertEqual(triggered_event.status, EventStatus.PROCESSED)
+            self.assertIn(triggered_event.transaction_id, transaction_ids)
+
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="sample.novu.com/v1/events/trigger/bulk",
+            headers={"Authorization": "ApiKey api-key"},
+            json={
+                "events": [
+                    {"name": "test-template", "to": "recipient_1", "payload": {}, "tenant": "tenant-id"},
+                    {"name": "test-template", "to": "recipient_2", "payload": {}},
+                ]
+            },
+            params=None,
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
     def test_broadcast_with_overrides(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.broadcast("test-template", {}, {"an": "override"})
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -488,14 +581,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_broadcast_with_actor(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.broadcast("test-template", {}, actor="actor-id")
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -513,14 +606,14 @@ class EventApiTests(TestCase):
     @mock.patch("requests.request")
     def test_broadcast_with_transaction_id(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(
-            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED.value, "transactionId": "sample-test"}}
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
         )
 
         result = self.api.broadcast("test-template", {}, transaction_id="sample-test")
 
         self.assertIsInstance(result, EventDto)
         self.assertTrue(result.acknowledged)
-        self.assertEqual(result.status, EventStatus.PROCESSED.value)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
         self.assertEqual(result.transaction_id, "sample-test")
         mock_request.assert_called_once_with(
             method="POST",
@@ -536,10 +629,35 @@ class EventApiTests(TestCase):
         )
 
     @mock.patch("requests.request")
+    def test_broadcast_with_tenant(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(
+            201, {"data": {"acknowledged": True, "status": EventStatus.PROCESSED, "transactionId": "sample-test"}}
+        )
+
+        result = self.api.broadcast("test-template", {}, tenant="tenant-id")
+
+        self.assertIsInstance(result, EventDto)
+        self.assertTrue(result.acknowledged)
+        self.assertEqual(result.status, EventStatus.PROCESSED)
+        self.assertEqual(result.transaction_id, "sample-test")
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="sample.novu.com/v1/events/trigger/broadcast",
+            headers={"Authorization": "ApiKey api-key"},
+            json={
+                "name": "test-template",
+                "payload": {},
+                "tenant": "tenant-id",
+            },
+            params=None,
+            timeout=5,
+        )
+
+    @mock.patch("requests.request")
     def test_delete(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(204)
 
-        self.assertIsNone(self.api.delete("sample-test"))
+        self.assertIsNone(self.api.delete("sample-test"))  # type: ignore
 
         mock_request.assert_called_once_with(
             method="DELETE",


### PR DESCRIPTION
Close #94

It seems important to me that we hotfix this functionality to quickly address the problem of maintaining the most used API of the project.

FYI @unicodeveloper @Cliftonz 
