### PR TITLE
feat: added missing regenerate api key method in Environments

### DIFF
--- a/novu/api/environment.py
+++ b/novu/api/environment.py
@@ -67,3 +67,15 @@ class EnvironmentApi(Api):
         results = self.handle_request("GET", f"{self._environment_url}/api-keys")["data"]
         for result in results:
             yield EnvironmentApiKeyDto.from_camel_case(result)
+
+    def regenerate_api_key(self) -> Iterator[EnvironmentApiKeyDto]:
+        """Regenerate an environment api key
+
+        Yields:
+            Mapped environment's api key
+        """
+        results = self.handle_request("POST", f"{self._environment_url}/api-keys/regenerate")["data"]
+        if not isinstance(results, list):
+            results = [results]
+        for result in results:
+            yield EnvironmentApiKeyDto.from_camel_case(result)

--- a/novu/api/environment.py
+++ b/novu/api/environment.py
@@ -75,7 +75,5 @@ class EnvironmentApi(Api):
             Mapped environment's api key
         """
         results = self.handle_request("POST", f"{self._environment_url}/api-keys/regenerate")["data"]
-        if not isinstance(results, list):
-            results = [results]
         for result in results:
             yield EnvironmentApiKeyDto.from_camel_case(result)

--- a/tests/api/test_environment.py
+++ b/tests/api/test_environment.py
@@ -132,7 +132,7 @@ class EnvironmentApiTests(TestCase):
 
     @mock.patch("requests.request")
     def test_regenerate_api_key(self, mock_request: mock.MagicMock) -> None:
-        mock_request.return_value = MockResponse(200, {"data": self.response_json_api_key})
+        mock_request.return_value = MockResponse(200, {"data": [self.response_json_api_key]})
 
         res = self.api.regenerate_api_key()
         self.assertIsInstance(res, types.GeneratorType)

--- a/tests/api/test_environment.py
+++ b/tests/api/test_environment.py
@@ -129,3 +129,20 @@ class EnvironmentApiTests(TestCase):
             params=None,
             timeout=5,
         )
+
+    @mock.patch("requests.request")
+    def test_regenerate_api_key(self, mock_request: mock.MagicMock) -> None:
+        mock_request.return_value = MockResponse(200, {"data": self.response_json_api_key})
+
+        res = self.api.regenerate_api_key()
+        self.assertIsInstance(res, types.GeneratorType)
+        self.assertEqual(list(res), [self.expected_dto_api_key])
+
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="sample.novu.com/v1/environments/api-keys/regenerate",
+            headers={"Authorization": "ApiKey api-key"},
+            json=None,
+            params=None,
+            timeout=5,
+        )


### PR DESCRIPTION
See https://docs.novu.co/api-reference/environments/regenerate-api-keys for more details

Part of #74 