### PR TITLE
fix(subscriber): prevent errors using bulk_create

### DIFF
--- a/novu/api/subscriber.py
+++ b/novu/api/subscriber.py
@@ -79,7 +79,9 @@ class SubscriberApi(Api):
         """
         return BulkResultSubscriberDto.from_camel_case(
             self.handle_request(
-                "POST", f"{self._subscriber_url}/bulk", [subscriber.to_camel_case() for subscriber in subscribers]
+                "POST",
+                f"{self._subscriber_url}/bulk",
+                {"subscribers": [subscriber.to_camel_case() for subscriber in subscribers]},
             ).get("data", {})
         )
 

--- a/tests/api/test_subscriber.py
+++ b/tests/api/test_subscriber.py
@@ -242,28 +242,30 @@ class SubscriberApiTests(TestCase):
             method="POST",
             url="sample.novu.com/v1/subscribers/bulk",
             headers={"Authorization": "ApiKey api-key"},
-            json=[
-                {
-                    "subscriberId": "subscriber-id",
-                    "email": "subscriber@sample.com",
-                    "firstName": None,
-                    "lastName": None,
-                    "phone": None,
-                    "avatar": None,
-                    "locale": None,
-                    "channels": None,
-                },
-                {
-                    "subscriberId": "subscriber1-id",
-                    "email": "subscriber1@sample.com",
-                    "firstName": None,
-                    "lastName": None,
-                    "phone": None,
-                    "avatar": None,
-                    "locale": None,
-                    "channels": None,
-                },
-            ],
+            json={
+                "subscribers": [
+                    {
+                        "subscriberId": "subscriber-id",
+                        "email": "subscriber@sample.com",
+                        "firstName": None,
+                        "lastName": None,
+                        "phone": None,
+                        "avatar": None,
+                        "locale": None,
+                        "channels": None,
+                    },
+                    {
+                        "subscriberId": "subscriber1-id",
+                        "email": "subscriber1@sample.com",
+                        "firstName": None,
+                        "lastName": None,
+                        "phone": None,
+                        "avatar": None,
+                        "locale": None,
+                        "channels": None,
+                    },
+                ]
+            },
             params=None,
             timeout=5,
         )


### PR DESCRIPTION
While testing new feature (bulk_create), find an error on the payload send to Novu serveur:

requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.novu.co/v1/subscribers/bulk

```json
{
    "message": [
        "subscribers must contain no more than 500 elements",
        "subscribers should not be empty",
        "subscribers must be an array",
    ],
    "error": "Bad Request",
    "statusCode": 400,
}
```

This MR patch this problem