### PR TITLE
feat(api): add transaction ID param to MessageApi list method

### DIFF
--- a/novu/api/message.py
+++ b/novu/api/message.py
@@ -25,7 +25,12 @@ class MessageApi(Api):
         self._message_url = f"{self._url}{MESSAGES_ENDPOINT}"
 
     def list(
-        self, limit: int = 10, page: int = 0, channel: Optional[str] = None, subscriber_id: Optional[str] = None
+        self,
+        limit: int = 10,
+        page: int = 0,
+        channel: Optional[str] = None,
+        subscriber_id: Optional[str] = None,
+        transaction_id: Optional[str] = None,
     ) -> PaginatedMessageDto:
         """List messages
 
@@ -34,6 +39,7 @@ class MessageApi(Api):
             page: The page to fetch, defaults to 0
             channel: The channel for the messages you wish to list. Defaults to None.
             subscriber_id: The subscriberId for the subscriber you like to list messages for
+            transaction_id: The transactionId for the messages you wish to list. Defaults to None.
 
         Returns:
             Returned a paginated struct containing retrieved messages
@@ -44,6 +50,8 @@ class MessageApi(Api):
             payload["channel"] = channel
         if subscriber_id:
             payload["subscriberId"] = subscriber_id
+        if transaction_id:
+            payload["transactionId"] = transaction_id
 
         return PaginatedMessageDto.from_camel_case(self.handle_request("GET", self._message_url, payload=payload))
 

--- a/tests/api/test_message.py
+++ b/tests/api/test_message.py
@@ -90,7 +90,9 @@ class MessageApiTests(TestCase):
     def test_list_messages_with_filters(self, mock_request: mock.MagicMock) -> None:
         mock_request.return_value = MockResponse(200, {"data": [self.response_json]})
 
-        res = self.api.list(10, 0, Channel.IN_APP.value, "63dafedbc037e013fd82d37a")
+        res = self.api.list(
+            10, 0, Channel.IN_APP.value, "63dafedbc037e013fd82d37a", "aa287682-cb30-4a5f-a03a-f28f59c9d46d"
+        )
         self.assertIsInstance(res, PaginatedMessageDto)
         self.assertEqual(list(res.data), [self.expected_dto])
 
@@ -99,7 +101,13 @@ class MessageApiTests(TestCase):
             url="sample.novu.com/v1/messages",
             headers={"Authorization": "ApiKey api-key"},
             json=None,
-            params={"limit": 10, "page": 0, "channel": "in_app", "subscriberId": "63dafedbc037e013fd82d37a"},
+            params={
+                "limit": 10,
+                "page": 0,
+                "channel": "in_app",
+                "subscriberId": "63dafedbc037e013fd82d37a",
+                "transactionId": "aa287682-cb30-4a5f-a03a-f28f59c9d46d",
+            },
             timeout=5,
         )
 


### PR DESCRIPTION
This pull request adds a new `transaction_id` parameter to the `MessageApi.list()` method. This parameter allows to specify a transaction ID to filter messages by.