### PR TITLE
Update the docstring for in operator

### DIFF
--- a/novu/enums/field.py
+++ b/novu/enums/field.py
@@ -45,7 +45,7 @@ class FieldFilterPartOperator(StrEnum):
     """Not LIKE operator (``not sentence.find(item)``)"""
 
     IN = "IN"
-    """Not equal operator (``in``)"""
+    """Membership operator (``in``)"""
 
 
 class FieldFilterPartOn(StrEnum):


### PR DESCRIPTION
This pull request updates the docstring for the `IN` operator in the `FieldFilterPartOperator` enumeration in the `novu.enums.polyfill` module. The existing docstring inaccurately describes the `IN` operator as a "Not equal" operator when, in fact, it is a membership operator used to check if an item is present in a collection.

I have corrected the docstring to provide a more accurate and clear description:
```python
"""Membership operator (``in``)"""